### PR TITLE
Read bboxDataNode attributes without namespace

### DIFF
--- a/PyWPS/pywps/Parser/Execute.py
+++ b/PyWPS/pywps/Parser/Execute.py
@@ -405,10 +405,9 @@ class Post(PostParser):
 
         attributes = {}
         attributes["value"] = []
-        attributes["crs"] = bboxDataNode.getAttributeNS(self.owsNameSpace,
-                                                                    "crs")
-        attributes["dimensions"] = int(bboxDataNode.getAttributeNS(
-                                        self.owsNameSpace, "dimensions"))
+
+        attributes["crs"] = bboxDataNode.getAttribute("crs")
+        attributes["dimensions"] = int(bboxDataNode.getAttribute("dimensions"))
 
         for coord in bboxDataNode.getElementsByTagNameNS(
                 self.owsNameSpace,"LowerCorner")[0].firstChild.nodeValue.split():


### PR DESCRIPTION
BoundingBoxData node attributes was read in "ows" namespace whereas BoundingBoxData node is in "wps" namespace.
I also notice that "crs" and "dimension attributes should be optional and int(bboxDataNode.getAttribute("dimensions")) raise an error when dimensions is missing.
